### PR TITLE
Persistent toasts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,13 +7,14 @@ import {
 
 import AppLayout from './AppLayout';
 import AuthenticatedRoute from './AuthenticatedRoute';
-import { Provider as ConfigProvider } from './ConfigContext';
 import Dashboard from './Dashboard';
 import FetchProvider from './FetchProvider';
 import NewSessionPage from './NewSessionPage';
 import SessionPage from './SessionPage';
 import SessionsPage from './SessionsPage';
+import { Provider as ConfigProvider } from './ConfigContext';
 import { Provider as CurrentUserProvider } from './CurrentUserContext';
+import * as Toast from './ToastContext';
 
 function App() {
   return (
@@ -21,24 +22,27 @@ function App() {
       <ConfigProvider>
         <Router basename={process.env.REACT_APP_MOUNT_PATH}>
           <CurrentUserProvider>
-            <FetchProvider>
-              <AppLayout>
-                <Switch>
-                  <AuthenticatedRoute path="/sessions/new">
-                    <NewSessionPage />
-                  </AuthenticatedRoute>
-                  <AuthenticatedRoute path="/sessions/:id">
-                    <SessionPage />
-                  </AuthenticatedRoute>
-                  <AuthenticatedRoute path="/sessions">
-                    <SessionsPage />
-                  </AuthenticatedRoute>
-                  <Route path="/">
-                    <Dashboard />
-                  </Route>
-                </Switch>
-              </AppLayout>
-            </FetchProvider>
+            <Toast.Provider>
+              <Toast.Container />
+              <FetchProvider>
+                <AppLayout>
+                  <Switch>
+                    <AuthenticatedRoute path="/sessions/new">
+                      <NewSessionPage />
+                    </AuthenticatedRoute>
+                    <AuthenticatedRoute path="/sessions/:id">
+                      <SessionPage />
+                    </AuthenticatedRoute>
+                    <AuthenticatedRoute path="/sessions">
+                      <SessionsPage />
+                    </AuthenticatedRoute>
+                    <Route path="/">
+                      <Dashboard />
+                    </Route>
+                  </Switch>
+                </AppLayout>
+              </FetchProvider>
+            </Toast.Provider>
           </CurrentUserProvider>
         </Router>
       </ConfigProvider>

--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Toast, ToastHeader, ToastBody } from 'reactstrap';
 
 import { CardFooter } from './CardParts';
 import { Context as ConfigContext } from './ConfigContext';
@@ -12,18 +11,17 @@ function DesktopCard({ desktop }) {
   const { loading, post, response } = useLaunchSession(desktop);
   const history = useHistory();
   const { addToast } = useToast();
+  const clusterName = useContext(ConfigContext).clusterName;
   const launchSession = () => {
     post().then((responseBody) => {
       if (response.ok) {
         history.push(`/sessions/${responseBody.id}`);
       } else {
-        const { removeToast } = addToast(
-          <LaunchErrorToast
-            desktop={desktop}
-            launchError={errorCode(responseBody)}
-            toggle={() => removeToast()}
-          />
-        );
+        addToast(launchErrorToast({
+          clusterName: clusterName,
+          desktop: desktop,
+          launchError: errorCode(responseBody),
+        }));
       }
     });
   };
@@ -60,8 +58,7 @@ function DesktopCard({ desktop }) {
   );
 }
 
-function LaunchErrorToast({ desktop, launchError, toggle }) {
-  const clusterName = useContext(ConfigContext).clusterName;
+function launchErrorToast({ clusterName, desktop, launchError }) {
   let body = (
     <div>
       Unfortunately there has been a problem launching your
@@ -81,19 +78,11 @@ function LaunchErrorToast({ desktop, launchError, toggle }) {
     );
   }
 
-  return (
-    <Toast isOpen={true}>
-      <ToastHeader
-        icon="danger"
-        toggle={toggle}
-      >
-        Failed to launch desktop
-      </ToastHeader>
-      <ToastBody>
-        {body}
-      </ToastBody>
-    </Toast>
-  );
+  return {
+    body,
+    icon: 'danger',
+    header: 'Failed to launch desktop',
+  };
 }
 
 export default DesktopCard;

--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -17,7 +17,7 @@ function DesktopCard({ desktop }) {
       if (response.ok) {
         history.push(`/sessions/${responseBody.id}`);
       } else {
-        const removeToast = addToast(
+        const { removeToast } = addToast(
           <LaunchErrorToast
             desktop={desktop}
             launchError={errorCode(responseBody)}

--- a/src/SignInForm.js
+++ b/src/SignInForm.js
@@ -1,7 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Toast, ToastHeader, ToastBody } from 'reactstrap';
 
-import Portal from './Portal';
 import { errorCode } from './utils';
 import { useSignIn } from './api';
 import { useToast } from './ToastContext';
@@ -33,9 +31,8 @@ function SignInForm() {
   const removeToastRef = useRef(null);
 
   async function showToast(response) {
-    const code = errorCode(await response.json());
     const { removeToast } = addToast(
-      <LoginErrorToast errorCode={code} toggle={() => removeToast()} />
+      loginErrorToast({ errorCode: errorCode(await response.json()) })
     );
     removeToastRef.current = removeToast;
   }
@@ -88,7 +85,7 @@ function SignInForm() {
   );
 }
 
-function LoginErrorToast({ errorCode, toggle }) {
+function loginErrorToast({ errorCode }) {
   let body = (
     <div>
       Unfortunately there has been an unexpected problem authenticating your
@@ -105,21 +102,11 @@ function LoginErrorToast({ errorCode, toggle }) {
     );
   }
 
-  return (
-    <Portal id="toast-portal">
-      <Toast isOpen={true}>
-        <ToastHeader
-          icon="danger"
-          toggle={toggle}
-        >
-          Unable to sign in to your account
-        </ToastHeader>
-        <ToastBody>
-          {body}
-        </ToastBody>
-      </Toast>
-    </Portal>
-  );
+  return {
+    body,
+    icon: 'danger',
+    header: 'Unable to sign in to your account',
+  };
 }
 
 export default SignInForm;

--- a/src/ToastContext.js
+++ b/src/ToastContext.js
@@ -1,0 +1,59 @@
+import React, { useContext, useMemo, useState } from 'react';
+import { v1 as uuidv1 } from 'uuid';
+
+import Portal from './Portal';
+
+const Context = React.createContext({});
+
+function Provider({ children }) {
+  const [toasts, setToasts] = useState([]);
+  const actions = useMemo(
+    () => ({
+      addToast(content) {
+        const id =  uuidv1();
+        const newToast = { content, id };
+        setToasts((toasts) => [ ...toasts, newToast ]);
+        return () => actions.removeToast(id);
+      },
+
+      removeToast(id) {
+        setToasts((toasts) => {
+          const idx = toasts.findIndex(t => t.id === id);
+          if (idx > -1) {
+            const before = toasts.slice(0, idx);
+            const after = toasts.slice(idx + 1, toasts.length);
+            return [ ...before, ...after ];
+          }
+        });
+      }
+    }),
+    [ setToasts ],
+  );
+
+  return (
+    <Context.Provider value={{ toasts, ...actions }}>
+      {children}
+    </Context.Provider>
+  );
+}
+
+function useToast() {
+  return useContext(Context);
+}
+
+function Container() {
+  const { toasts } = useToast();
+
+  return (
+    <Portal id="toast-portal">
+      { toasts.map(t => React.cloneElement(t.content, {key: t.id})) }
+    </Portal>
+  );
+}
+
+export {
+  Container,
+  Context,
+  Provider,
+  useToast,
+}

--- a/src/ToastContext.js
+++ b/src/ToastContext.js
@@ -22,7 +22,9 @@ function Provider({ children }) {
       removeToast(id) {
         setToasts((toasts) => {
           const idx = toasts.findIndex(t => t.id === id);
-          if (idx > -1) {
+          if (idx === -1) {
+            return toasts;
+          } else {
             const before = toasts.slice(0, idx);
             const after = toasts.slice(idx + 1, toasts.length);
             return [ ...before, ...after ];

--- a/src/ToastContext.js
+++ b/src/ToastContext.js
@@ -13,7 +13,10 @@ function Provider({ children }) {
         const id =  uuidv1();
         const newToast = { content, id };
         setToasts((toasts) => [ ...toasts, newToast ]);
-        return () => actions.removeToast(id);
+        return {
+          id,
+          removeToast() { actions.removeToast(id) },
+        };
       },
 
       removeToast(id) {

--- a/src/ToastContext.js
+++ b/src/ToastContext.js
@@ -1,4 +1,5 @@
 import React, { useContext, useMemo, useState } from 'react';
+import { Toast, ToastHeader, ToastBody } from 'reactstrap';
 import { v1 as uuidv1 } from 'uuid';
 
 import Portal from './Portal';
@@ -47,11 +48,29 @@ function useToast() {
 }
 
 function Container() {
-  const { toasts } = useToast();
+  const { toasts, removeToast } = useToast();
 
   return (
     <Portal id="toast-portal">
-      { toasts.map(t => React.cloneElement(t.content, {key: t.id})) }
+      {
+        toasts.map(t => (
+          <Toast isOpen={true} key={t.id}>
+            <ToastHeader
+              icon={t.content.icon}
+              toggle={
+                t.content.toggle != null ?
+                  t.content.toggle :
+                  () => removeToast(t.id)
+              }
+            >
+              {t.content.header}
+            </ToastHeader>
+            <ToastBody>
+              {t.content.body}
+            </ToastBody>
+          </Toast>
+        ))
+      }
     </Portal>
   );
 }

--- a/src/api.js
+++ b/src/api.js
@@ -3,7 +3,7 @@ import useFetch from 'use-http';
 
 import { Context as CurrentUserContext } from './CurrentUserContext';
 
-export function useSignIn() {
+export function useSignIn({ onError }) {
   const {
     error,
     get,
@@ -18,8 +18,8 @@ export function useSignIn() {
         await get();
         if (response.ok) {
           userActions.promoteUser(tempUser);
-        } else if (response.status === 401) {
-          console.log('user unauthed');
+        } else {
+          typeof onError === 'function' && onError(response);
         }
       }
     }


### PR DESCRIPTION
This PR adds support for toasts that do not disappear on each navigation.

A new component `Toast` context has been created.  It provides an API to `addToast` and `removeToast` and stores the toasts using `useState`.

A new component `ToastContainer` has been created.  It uses the `Toast` context to obtain any active toasts.  These are then layed out using bootstraps `Toast` components and rendered via a `Portal`.

Fixes #7 