### PR TITLE
Session card improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "d3-time-format": "^2.2.3",
     "novnc-core": "^0.2.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/public/config.dev.json
+++ b/public/config.dev.json
@@ -1,8 +1,8 @@
 {
-  "clusterName": "Desktop Access Test 2",
+  "clusterName": "Desktop Access Test 5",
   "clusterDescription": "Self-managed in-cloud openflightHPC Cluster.  Interactive desktop sessions and much HPC.",
   "clusterLogo": "https://s3.eu-west-2.amazonaws.com/alces-flight-center/logos/Alces_flight_logo_horiz.png",
-  "apiRootUrl": "https://34.242.188.243/desktop/api",
+  "apiRootUrl": "https://52.212.74.7/desktop/api",
   "websocketPathPrefix": "/ws",
   "websocketPathIp": "127.0.0.1"
 }

--- a/src/CleanSessionButton.js
+++ b/src/CleanSessionButton.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import ConfirmedActionButton from './ConfirmedActionButton';
-import { prettyDesktopName } from './utils';
+import { errorCode, prettyDesktopName } from './utils';
 import { useCleanSession } from './api';
+import { useToast } from './ToastContext';
 
 function CleanSessionButton({
   className,
@@ -11,10 +12,26 @@ function CleanSessionButton({
   session,
 }) {
   const id = `clean-session-${session.id}`;
-  const { loading: cleaning, del } = useCleanSession(session.id);
-  const cleanSession = () => {
+  const { loading: cleaning, del, response } = useCleanSession(session.id);
+  const { addToast } = useToast();
+  const cleanSession = async () => {
     onClean();
-    del().then(onCleaned);
+    try {
+      const responseBody = await del();
+      if (response.ok) {
+        onCleaned();
+      } else {
+        addToast(cleanFailedToast({
+          session: session,
+          errorCode: errorCode(responseBody),
+        }));
+      }
+    } catch (e) {
+      addToast(cleanFailedToast({
+        session: session,
+        errorCode: undefined,
+      }));
+    }
   };
 
   return (
@@ -33,6 +50,27 @@ function CleanSessionButton({
       id={id}
     />
   );
+}
+
+function cleanFailedToast({ session, errorCode }) {
+  const desktopName = prettyDesktopName[session.desktop];
+  const sessionName = session.name || session.id.split('-')[0];
+
+  let body = (
+    <div>
+      Unfortunately there has been a problem cleaning your
+      {' '}<strong>{desktopName}</strong> desktop session
+      {' '}<strong>{sessionName}</strong>.  Please try again and, if problems
+      persist, help us to more quickly rectify the problem by contacting us
+      and letting us know.
+    </div>
+  );
+
+  return {
+    body,
+    icon: 'danger',
+    header: 'Failed to clean session',
+  };
 }
 
 export default CleanSessionButton;

--- a/src/CleanSessionButton.js
+++ b/src/CleanSessionButton.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import ConfirmedActionButton from './ConfirmedActionButton';
+import { prettyDesktopName } from './utils';
+import { useCleanSession } from './api';
+
+function CleanSessionButton({
+  className,
+  onClean=()=>{},
+  onCleaned=()=>{},
+  session,
+}) {
+  const id = `clean-session-${session.id}`;
+  const { loading: cleaning, del } = useCleanSession(session.id);
+  const cleanSession = () => {
+    onClean();
+    del().then(onCleaned);
+  };
+
+  return (
+    <ConfirmedActionButton
+      act={cleanSession}
+      acting={cleaning}
+      actingButtonText="Cleaning..."
+      buttonText="Clean"
+      className={className}
+      confirmationHeaderText="Confirm session cleanup"
+      confirmationText={<p>
+        Are you sure you want to clean this
+        {' '}<strong>{prettyDesktopName[session.desktop]}</strong> session?
+      </p>}
+      icon="fa-times"
+      id={id}
+    />
+  );
+}
+
+export default CleanSessionButton;

--- a/src/ConfirmedActionButton.js
+++ b/src/ConfirmedActionButton.js
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  ButtonToolbar,
+  Popover,
+  PopoverBody,
+  PopoverHeader,
+} from 'reactstrap';
+
+function ConfirmedActionButton({
+  act,
+  acting,
+  actingButtonText,
+  buttonText,
+  className,
+  confirmationHeaderText,
+  confirmationText,
+  icon,
+  id,
+}) {
+  const [showConfirmation, setShowConfirmation]  = useState(false);
+  const toggle = () => setShowConfirmation(!showConfirmation);
+
+  return (
+    <React.Fragment>
+      <Button
+        className={`btn btn-danger ${acting ? 'disabled' : null} ${className}`}
+        disabled={acting}
+        id={id}
+        size="sm"
+      >
+        {
+          acting ?
+            <i className="fa fa-spinner fa-spin mr-1"></i> :
+            <i className={`fa ${icon} mr-1`}></i>
+        }
+        <span>{ acting ? actingButtonText : buttonText }</span>
+      </Button>
+      <Popover
+        isOpen={showConfirmation}
+        target={id}
+        toggle={toggle}
+      >
+        <PopoverHeader>
+          {confirmationHeaderText}
+        </PopoverHeader>
+        <PopoverBody>
+          {confirmationText}
+          <ButtonToolbar className="justify-content-center">
+            <Button
+              className="mr-2"
+              onClick={toggle}
+              size="sm"
+            >
+              Cancel
+            </Button>
+            <Button
+              color="danger"
+              onClick={() => { toggle(); act(); }}
+              size="sm"
+            >
+              <i className={`fa ${icon} mr-1`}></i>
+              <span>{buttonText}</span>
+            </Button>
+          </ButtonToolbar>
+        </PopoverBody>
+      </Popover>
+    </React.Fragment>
+  );
+}
+
+export default ConfirmedActionButton;

--- a/src/Screenshot.js
+++ b/src/Screenshot.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link } from "react-router-dom";
+
+import placeholderImage from './placeholder.jpg';
+import { useFetchScreenshot } from './api';
+import { useInterval } from './utils';
+
+function Screenshot({ session }) {
+  const { get: getScreenshot, image: screenshot } = useFetchScreenshot(session.id);
+  useInterval(getScreenshot, 1 * 60 * 1000, { immediate: false });
+
+  const img = (
+    <img
+      className="card-img"
+      src={screenshot != null ? screenshot : placeholderImage}
+      alt="Session screenshot"
+    />
+  );
+
+  if (session.state === 'Active') {
+    return <Link to={`/sessions/${session.id}`}>{img}</Link>;
+  } else {
+    return img;
+  }
+}
+
+export default Screenshot;

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import { Link } from "react-router-dom";
+import * as d3 from "d3-time-format";
 
 import TerminateButton from './TerminateButton';
 import placeholderImage from './placeholder.jpg';
 import { CardFooter } from './CardParts';
 import { prettyDesktopName, useInterval } from './utils';
 import { useFetchScreenshot, useTerminateSession } from './api';
+
+const timeFormat = d3.timeFormat("%a %e %b %Y %H:%M");
+
+function timestampFormat(timestamp) {
+  return timeFormat(new Date(timestamp));
+}
 
 function SessionCard({ reload, session }) {
   const { get: getScreenshot, image: screenshot } = useFetchScreenshot(session.id);
@@ -37,18 +44,20 @@ function SessionCard({ reload, session }) {
             </div>
           </div>
           <dl className="row">
-            <dt
-              className="col-sm-4 text-truncate"
-              title="Desktop"
-            >
-              Desktop
-            </dt>
-            <dd
-              className="col-sm-8 text-truncate"
-              title={prettyDesktopName[session.desktop]}
-            >
-              {prettyDesktopName[session.desktop]}
-            </dd>
+            <MetadataEntry
+              name="Desktop"
+              value={prettyDesktopName[session.desktop] || session.desktop}
+            />
+            <MetadataEntry
+              name="Started"
+              value={session.created_at}
+              format={timestampFormat}
+            />
+            <MetadataEntry
+              name="Last accessed"
+              value={session.last_accessed_at}
+              format={timestampFormat}
+            />
           </dl>
         </div>
         <CardFooter>
@@ -69,6 +78,29 @@ function SessionCard({ reload, session }) {
           </div>
         </CardFooter>
       </div>
+  );
+}
+
+function MetadataEntry({ name, value, format }) {
+  if (value == null) {
+    return null;
+  }
+  const formatted = typeof format === "function" ? format(value) : value;
+  return (
+    <React.Fragment>
+      <dt
+        className="col-sm-4 text-truncate"
+        title={name}
+      >
+        {name}
+      </dt>
+      <dd
+        className="col-sm-8 text-truncate"
+        title={formatted}
+      >
+        {formatted}
+      </dd>
+    </React.Fragment>
   );
 }
 

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -7,7 +7,7 @@ import TerminateButton from './TerminateButton';
 import placeholderImage from './placeholder.jpg';
 import { CardFooter } from './CardParts';
 import { prettyDesktopName, useInterval } from './utils';
-import { useFetchScreenshot, useTerminateSession } from './api';
+import { useFetchScreenshot } from './api';
 
 const timeFormat = d3.timeFormat("%a %e %b %Y %H:%M");
 
@@ -19,10 +19,6 @@ function SessionCard({ reload, session }) {
   const { get: getScreenshot, image: screenshot } = useFetchScreenshot(session.id);
   useInterval(getScreenshot, 1 * 60 * 1000, { immediate: false });
   const session_name = session.name || session.id.split('-')[0];
-  const { loading, del } = useTerminateSession(session.id);
-  const terminateSession = () => {
-    del().then(() => reload());
-  };
 
   return (
       <div
@@ -68,9 +64,8 @@ function SessionCard({ reload, session }) {
         <CardFooter>
           <Buttons
             onCleaned={reload}
+            onTerminated={reload}
             session={session} 
-            terminateSession={terminateSession}
-            terminating={loading}
           />
         </CardFooter>
       </div>
@@ -100,7 +95,7 @@ function MetadataEntry({ name, value, format }) {
   );
 }
 
-function Buttons({ onCleaned, session, terminating, terminateSession }) {
+function Buttons({ onCleaned, onTerminated, session }) {
   if (session.state === 'Active') {
     return (
       <div className="btn-toolbar justify-content-center">
@@ -113,9 +108,8 @@ function Buttons({ onCleaned, session, terminating, terminateSession }) {
         </Link>
         <TerminateButton
           className="btn-sm"
+          onTerminated={onTerminated}
           session={session}
-          terminateSession={terminateSession}
-          terminating={terminating}
         />
       </div>
     );

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -43,11 +43,22 @@ function SessionCard({ reload, session }) {
           <dl className="row">
             <MetadataEntry
               name="Desktop"
-              value={prettyDesktopName[session.desktop] || session.desktop}
+              value={
+                prettyDesktopName[session.desktop] || session.desktop || <em>Unknown</em>
+              }
+              valueTitle={
+                prettyDesktopName[session.desktop] || session.desktop || 'Unknown'
+              }
             />
             <MetadataEntry
               name="State"
               value={session.state}
+              valueTitle={
+                session.state === 'Active' ?
+                  'This session is active.  You can connect to it to gain access.' :
+                  'This session is no longer available.  To remove it from ' +
+                  'this list, click the "Clean" button below.'
+              }
             />
             <MetadataEntry
               name="Started"
@@ -72,7 +83,7 @@ function SessionCard({ reload, session }) {
   );
 }
 
-function MetadataEntry({ name, value, format }) {
+function MetadataEntry({ name, value, format, valueTitle }) {
   if (value == null) {
     return null;
   }
@@ -87,7 +98,7 @@ function MetadataEntry({ name, value, format }) {
       </dt>
       <dd
         className="col-sm-8 text-truncate"
-        title={formatted}
+        title={valueTitle || formatted}
       >
         {formatted}
       </dd>

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from "react-router-dom";
 import * as d3 from "d3-time-format";
 
+import CleanButton from './CleanSessionButton';
 import TerminateButton from './TerminateButton';
 import placeholderImage from './placeholder.jpg';
 import { CardFooter } from './CardParts';
@@ -49,6 +50,10 @@ function SessionCard({ reload, session }) {
               value={prettyDesktopName[session.desktop] || session.desktop}
             />
             <MetadataEntry
+              name="State"
+              value={session.state}
+            />
+            <MetadataEntry
               name="Started"
               value={session.created_at}
               format={timestampFormat}
@@ -61,21 +66,12 @@ function SessionCard({ reload, session }) {
           </dl>
         </div>
         <CardFooter>
-          <div className="btn-toolbar justify-content-center">
-            <Link
-              className="btn btn-sm btn-primary mr-2"
-              to={`/sessions/${session.id}`}
-            >
-              <i className="fa fa-bolt mr-1"></i>
-              <span>Connect</span>
-            </Link>
-            <TerminateButton
-              className="btn-sm"
-              session={session}
-              terminateSession={terminateSession}
-              terminating={loading}
-            />
-          </div>
+          <Buttons
+            onCleaned={reload}
+            session={session} 
+            terminateSession={terminateSession}
+            terminating={loading}
+          />
         </CardFooter>
       </div>
   );
@@ -102,6 +98,38 @@ function MetadataEntry({ name, value, format }) {
       </dd>
     </React.Fragment>
   );
+}
+
+function Buttons({ onCleaned, session, terminating, terminateSession }) {
+  if (session.state === 'Active') {
+    return (
+      <div className="btn-toolbar justify-content-center">
+        <Link
+          className="btn btn-sm btn-primary mr-2"
+          to={`/sessions/${session.id}`}
+        >
+          <i className="fa fa-bolt mr-1"></i>
+          <span>Connect</span>
+        </Link>
+        <TerminateButton
+          className="btn-sm"
+          session={session}
+          terminateSession={terminateSession}
+          terminating={terminating}
+        />
+      </div>
+    );
+  } else {
+    return (
+      <div className="btn-toolbar justify-content-center">
+        <CleanButton
+          className="btn-sm"
+          onCleaned={onCleaned}
+          session={session}
+        />
+      </div>
+    );
+  }
 }
 
 export default SessionCard;

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -4,11 +4,10 @@ import classNames from 'classnames';
 import { Link } from "react-router-dom";
 
 import CleanButton from './CleanSessionButton';
+import Screenshot from './Screenshot';
 import TerminateButton from './TerminateButton';
-import placeholderImage from './placeholder.jpg';
 import { CardFooter } from './CardParts';
-import { prettyDesktopName, useInterval } from './utils';
-import { useFetchScreenshot } from './api';
+import { prettyDesktopName } from './utils';
 
 const timeFormat = d3.timeFormat("%a %e %b %Y %H:%M");
 
@@ -17,8 +16,6 @@ function timestampFormat(timestamp) {
 }
 
 function SessionCard({ reload, session }) {
-  const { get: getScreenshot, image: screenshot } = useFetchScreenshot(session.id);
-  useInterval(getScreenshot, 1 * 60 * 1000, { immediate: false });
   const sessionName = session.name || session.id.split('-')[0];
 
   return (
@@ -36,13 +33,7 @@ function SessionCard({ reload, session }) {
         }>
           <div className="row mb-2">
             <div className="col">
-              <Link to={`/sessions/${session.id}`}>
-                <img
-                  className="card-img"
-                  src={screenshot != null ? screenshot : placeholderImage}
-                  alt="Session screenshot"
-                />
-              </Link>
+              <Screenshot session={session} />
             </div>
           </div>
           <dl className="row">

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Link } from "react-router-dom";
 import * as d3 from "d3-time-format";
+import React from 'react';
+import classNames from 'classnames';
+import { Link } from "react-router-dom";
 
 import CleanButton from './CleanSessionButton';
 import TerminateButton from './TerminateButton';
@@ -22,13 +23,17 @@ function SessionCard({ reload, session }) {
 
   return (
       <div
-        className="card border-primary mb-2"
+        className={classNames('card border-primary mb-2', {
+          [`session--${session.state.toLowerCase()}`]: true,
+        })}
         data-testid="session-card"
       >
         <h5 className="card-header bg-primary text-light">
           {sessionName}
         </h5>
-        <div className="card-body">
+        <div className={
+          classNames("card-body", { 'text-muted': session.state !== 'Active' })
+        }>
           <div className="row mb-2">
             <div className="col">
               <Link to={`/sessions/${session.id}`}>

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -18,7 +18,7 @@ function timestampFormat(timestamp) {
 function SessionCard({ reload, session }) {
   const { get: getScreenshot, image: screenshot } = useFetchScreenshot(session.id);
   useInterval(getScreenshot, 1 * 60 * 1000, { immediate: false });
-  const session_name = session.name || session.id.split('-')[0];
+  const sessionName = session.name || session.id.split('-')[0];
 
   return (
       <div
@@ -26,7 +26,7 @@ function SessionCard({ reload, session }) {
         data-testid="session-card"
       >
         <h5 className="card-header bg-primary text-light">
-          {session_name}
+          {sessionName}
         </h5>
         <div className="card-body">
           <div className="row mb-2">

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -10,7 +10,7 @@ import placeholderImage from './placeholder.jpg';
 import { Context as ConfigContext } from './ConfigContext';
 import { DefaultErrorMessage } from './ErrorBoundary';
 import { useFetchScreenshot } from './api';
-import { useFetchSession, useTerminateSession } from './api';
+import { useFetchSession } from './api';
 
 function buildWebsocketUrl(session, config) {
   if (config.devOnlyWebsocketRootUrl) {
@@ -80,11 +80,6 @@ function Connected({ id, screenshot, session }) {
   const config = useContext(ConfigContext);
   const history = useHistory();
   const vnc = useRef(null);
-  const { del, loading: terminating } = useTerminateSession(id);
-  const terminateSession = () => {
-    setConnectionState('terminating');
-    del().then(() => history.push(`/sessions`));
-  };
   const websocketUrl = buildWebsocketUrl(session, config);
   function onReconnect() {
     if (vnc.current) {
@@ -103,9 +98,9 @@ function Connected({ id, screenshot, session }) {
         }
       }}
       onReconnect={onReconnect}
-      onTerminate={terminateSession}
+      onTerminate={() => setConnectionState('terminating')}
+      onTerminated={() => history.push('/sessions')}
       session={session}
-      terminating={terminating}
     >
       <ErrorBoundary>
         <ConnectStateIndicator
@@ -140,8 +135,8 @@ function Layout({
   onDisconnect,
   onReconnect,
   onTerminate,
+  onTerminated,
   session,
-  terminating,
 }) {
   // `id` could be null when we are navigating away from the page.
   const { id } = useParams();
@@ -164,8 +159,8 @@ function Layout({
                       onDisconnect={onDisconnect}
                       onReconnect={onReconnect}
                       onTerminate={onTerminate}
+                      onTerminated={onTerminated}
                       session={session}
-                      terminating={terminating}
                     />
                   </div>
                 </div>
@@ -186,8 +181,8 @@ function Toolbar({
   onDisconnect,
   onReconnect,
   onTerminate,
+  onTerminated,
   session,
-  terminating,
 }) {
   const disconnectBtn = connectionState === 'connected' ? (
     <button
@@ -213,8 +208,8 @@ function Toolbar({
     <TerminateButton
       className="btn-sm"
       session={session}
-      terminateSession={onTerminate}
-      terminating={terminating}
+      onTerminate={onTerminate}
+      onTerminated={onTerminated}
     >
     </TerminateButton>
   ) : null;

--- a/src/SessionsPage.test.js
+++ b/src/SessionsPage.test.js
@@ -58,6 +58,7 @@ describe('screenshots', () => {
     {
       "id": "410bc483-710c-4795-a859-baeae17f08ce",
       "desktop": "terminal",
+      "state": "Active",
     },
   ];
 
@@ -102,10 +103,12 @@ describe('when there are running sessions', () => {
     {
       "id": "410bc483-710c-4795-a859-baeae17f08ce",
       "desktop": "terminal",
+      "state": "Active",
     },
     {
       "id": "1740a970-73e2-42bb-b740-baadb333175d",
       "desktop": "chrome",
+      "state": "Exited",
     },
   ];
 
@@ -136,18 +139,32 @@ describe('when there are running sessions', () => {
   });
 
   test('session cards have correct buttons', async () => {
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0].state).toEqual('Active');
+    expect(sessions[1].state).toEqual('Exited');
+
     const { getAllByTestId } = await renderSessionsPage();
     const cards = getAllByTestId('session-card');
 
+    expect(cards).toHaveLength(2);
     cards.forEach((card, index) => {
       const session = sessions[index];
-      const { getByRole } = within(card);
+      const { queryByRole } = within(card);
 
-      const connectLink = getByRole("link", { name: "Connect" });
-      expect(connectLink).toHaveAttribute("href", `/sessions/${session.id}`);
+      const connectLink = queryByRole("link", { name: "Connect" });
+      const terminateBtn = queryByRole("button", { name: "Terminate" });
+      const cleanButton = queryByRole("button", { name: "Clean" });
 
-      const terminateBtn = getByRole("button", { name: "Terminate" });
-      expect(terminateBtn).toBeInTheDocument();
+      if (session.state === "Active") {
+        expect(connectLink).toBeInTheDocument("href", `/sessions/${session.id}`);
+        expect(connectLink).toHaveAttribute("href", `/sessions/${session.id}`);
+        expect(terminateBtn).toBeInTheDocument();
+        expect(cleanButton).toBeNull();
+      } else {
+        expect(connectLink).toBeNull();
+        expect(terminateBtn).toBeNull();
+        expect(cleanButton).toBeInTheDocument();
+      }
     });
   });
 });
@@ -195,6 +212,7 @@ describe('periodic reloading of the sessions data', () => {
       "id": "410bc483-710c-4795-a859-baeae17f08ce",
       "desktop": "terminal",
       "image": "totally some PNG image data",
+      "state": "Active",
     },
   ]};
   const secondResponse = { data: [
@@ -202,11 +220,13 @@ describe('periodic reloading of the sessions data', () => {
       "id": "410bc483-710c-4795-a859-baeae17f08ce",
       "desktop": "terminal",
       "image": "totally some PNG image data",
+      "state": "Active",
     },
     {
       "id": "1740a970-73e2-42bb-b740-baadb333175d",
       "desktop": "chrome",
       "image": null,
+      "state": "Active",
     },
   ]};
 

--- a/src/TerminateButton.js
+++ b/src/TerminateButton.js
@@ -2,14 +2,20 @@ import React from 'react';
 
 import ConfirmedActionButton from './ConfirmedActionButton';
 import { prettyDesktopName } from './utils';
+import { useTerminateSession } from './api';
 
 function TerminateButton({
   className,
+  onTerminate=()=>{},
+  onTerminated=()=>{},
   session,
-  terminating,
-  terminateSession,
 }) {
   const id = `terminate-session-${session.id}`;
+  const { loading: terminating, del } = useTerminateSession(session.id);
+  const terminateSession = () => {
+    onTerminate();
+    del().then(onTerminated);
+  };
 
   return (
     <ConfirmedActionButton

--- a/src/TerminateButton.js
+++ b/src/TerminateButton.js
@@ -1,71 +1,39 @@
-import React, { useState } from 'react';
-import {
-  Button,
-  ButtonToolbar,
-  Popover,
-  PopoverBody,
-  PopoverHeader,
-} from 'reactstrap';
+import React from 'react';
 
+import ConfirmedActionButton from './ConfirmedActionButton';
 import { prettyDesktopName } from './utils';
 
-function TerminateButton({ className, terminating, terminateSession, session }) {
-  const [showConfirmation, setShowConfirmation]  = useState(false);
-  const toggle = () => setShowConfirmation(!showConfirmation);
+function TerminateButton({
+  className,
+  session,
+  terminating,
+  terminateSession,
+}) {
   const id = `terminate-session-${session.id}`;
 
   return (
-    <>
-    <Button
-      className={`btn btn-danger ${terminating ? 'disabled' : null} ${className}`}
-      disabled={terminating}
-      id={id}
-      size="sm"
-    >
-      {
-        terminating ?
-          <i className="fa fa-spinner fa-spin mr-1"></i> :
-          <i className="fa fa-trash mr-1"></i>
+    <ConfirmedActionButton
+      act={terminateSession}
+      acting={terminating}
+      actingButtonText="Terminating..."
+      buttonText="Terminate"
+      className={className}
+      confirmationHeaderText="Confirm termination"
+      confirmationText={
+        <React.Fragment>
+          <p>
+            Are you sure you want to terminate this
+            {' '}<strong>{prettyDesktopName[session.desktop]}</strong> session?
+          </p>
+          <p>
+            All trace of this session will be removed and any unsaved work will
+            be lost.
+          </p>
+        </React.Fragment>
       }
-      <span>{ terminating ? 'Terminating...' : 'Terminate' }</span>
-    </Button>
-    <Popover
-      isOpen={showConfirmation}
-      target={id}
-      toggle={toggle}
-    >
-      <PopoverHeader>
-        Confirm termination
-      </PopoverHeader>
-      <PopoverBody>
-        <p>
-          Are you sure you want to terminate this
-          {' '}<strong>{prettyDesktopName[session.desktop]}</strong> session?
-        </p>
-        <p>
-          All trace of this session will be removed and any unsaved work will
-          be lost.
-        </p>
-        <ButtonToolbar className="justify-content-center">
-          <Button
-            className="mr-2"
-            onClick={toggle}
-            size="sm"
-          >
-            Cancel
-          </Button>
-          <Button
-            color="danger"
-            onClick={() => { toggle(); terminateSession(); }}
-            size="sm"
-          >
-            <i className="fa fa-trash mr-1"></i>
-            <span>Terminate</span>
-          </Button>
-        </ButtonToolbar>
-      </PopoverBody>
-    </Popover>
-    </>
+      icon="fa-trash"
+      id={id}
+    />
   );
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -88,6 +88,18 @@ export function useLaunchSession(desktop) {
   return request;
 }
 
+export function useCleanSession(id) {
+  const request = useFetch({
+    method: 'delete',
+    path: `/sessions/${id}`,
+    body: {
+      strategy: 'clean-only',
+    },
+    cachePolicy: 'no-cache',
+  });
+  return request;
+}
+
 export function useTerminateSession(id) {
   const request = useFetch({
     method: 'delete',

--- a/src/index.css
+++ b/src/index.css
@@ -88,3 +88,8 @@ footer {
 .desktop--unverified .card-footer {
     opacity: 0.5;
 }
+
+.session--broken .card-body img,
+.session--exited .card-body img {
+    opacity: 0.5;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,6 +2979,16 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
 
+d3-time-format@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.2.3.tgz#0c9a12ee28342b2037e5ea1cf0b9eb4dd75f29cb"
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"


### PR DESCRIPTION
Add more metadata to the session cards.  This includes the state of the session (Active, Broken or Exited) and the session creation and last access times.

Improve support for non-active sessions.  They are now visually distinguished from active sessions.  They have an explanation of what they are and what can be done with them.  A "Clean" button is provided instead of "Connect" and "Terminate" buttons.  The screenshot no longer links to the connection page.

Fixes #19 
Refs #23 