### PR TITLE
Bling for desktops and sessions pages

### DIFF
--- a/src/DesktopsPage.js
+++ b/src/DesktopsPage.js
@@ -63,27 +63,18 @@ function DesktopsList({ desktops }) {
   return (
     <React.Fragment>
       <StyledJumbotron className="bg-white py-4">
-        <div className="row">
-          <div className="col">
-            <h1>
-              Launch a new desktop session
-            </h1>
-            <p>
-              To launch a new desktop session
-            </p>
-            <ul>
-              <li>Select the desktop session type from the list below.</li>
-              <li>Click "Launch".</li>
-              <li>When your session is ready you will be automatically connected to it.</li>
-              <li>Start working!</li>
-            </ul>
-          </div>
-          {/*
-          <div className="col-2">
-            <i className="fa fa-rocket fa-4x text-success"></i>
-          </div>
-          */}
-        </div>
+        <h1>
+          Launch a new desktop session
+        </h1>
+        <p>
+          To launch a new desktop session
+        </p>
+        <ul>
+          <li>Select the desktop session type from the list below.</li>
+          <li>Click "Launch".</li>
+          <li>When your session is ready you will be automatically connected to it.</li>
+          <li>Start working!</li>
+        </ul>
       </StyledJumbotron>
       {decks}
     </React.Fragment>
@@ -117,19 +108,6 @@ const StyledJumbotron = styled(Jumbotron)`
       transform: translateY(-50%);
     }
   }
-  /*
-
-  .fa {
-    transform: translate(-50%, -50%);
-    top: 50%;
-    position: absolute;
-    left: 50%;
-    font-size: 8em;
-    opacity: 0.2;
-  }
-
-  */
-
 `;
 
 export default DesktopsPage;

--- a/src/DesktopsPage.js
+++ b/src/DesktopsPage.js
@@ -63,18 +63,27 @@ function DesktopsList({ desktops }) {
   return (
     <React.Fragment>
       <StyledJumbotron className="bg-white py-4">
-        <h1>
-          Launch a new desktop session
-        </h1>
-        <p>
-          To launch a new desktop session
-        </p>
-        <ul>
-          <li>Select the desktop session type from the list below.</li>
-          <li>Click "Launch".</li>
-          <li>When your session is ready you will be automatically connected to it.</li>
-          <li>Start working!</li>
-        </ul>
+        <div className="row">
+          <div className="col">
+            <h1>
+              Launch a new desktop session
+            </h1>
+            <p>
+              To launch a new desktop session
+            </p>
+            <ul>
+              <li>Select the desktop session type from the list below.</li>
+              <li>Click "Launch".</li>
+              <li>When your session is ready you will be automatically connected to it.</li>
+              <li>Start working!</li>
+            </ul>
+          </div>
+          {/*
+          <div className="col-2">
+            <i className="fa fa-rocket fa-4x text-success"></i>
+          </div>
+          */}
+        </div>
       </StyledJumbotron>
       {decks}
     </React.Fragment>
@@ -85,18 +94,42 @@ const StyledJumbotron = styled(Jumbotron)`
   position:relative;
 
   :before {
-    bottom: 0;
     color: var(--success);
+    content: "\f135";
     font-family: FontAwesome;
-    font-size: 900%;
-    /* left: 0; */
+    font-size: 12em;
     opacity: 0.2;
     position: absolute;
-    right: 1.5rem;
     text-align: center;
-    top: 0;
-    content: "\f135";
+
+    @media (max-width: 1099.98px) {
+      top: 50%;
+      left: 50%;
+      bottom: unset;
+      right: unset;
+      transform: translate(-50%, -50%);
+    }
+    @media (min-width: 1100px) {
+      top: 50%;
+      left: unset;
+      bottom: unset;
+      right: 32px;
+      transform: translateY(-50%);
+    }
   }
+  /*
+
+  .fa {
+    transform: translate(-50%, -50%);
+    top: 50%;
+    position: absolute;
+    left: 50%;
+    font-size: 8em;
+    opacity: 0.2;
+  }
+
+  */
+
 `;
 
 export default DesktopsPage;

--- a/src/DesktopsPage.js
+++ b/src/DesktopsPage.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Jumbotron } from 'reactstrap';
+import styled from 'styled-components'
 
 import DesktopCard from './DesktopCard';
 import Overlay, { OverlayContainer } from './Overlay';
@@ -59,8 +61,8 @@ function DesktopsList({ desktops }) {
   );
 
   return (
-    <div>
-      <div className="jumbotron bg-white py-4">
+    <React.Fragment>
+      <StyledJumbotron className="bg-white py-4">
         <h1>
           Launch a new desktop session
         </h1>
@@ -73,10 +75,28 @@ function DesktopsList({ desktops }) {
           <li>When your session is ready you will be automatically connected to it.</li>
           <li>Start working!</li>
         </ul>
-      </div>
+      </StyledJumbotron>
       {decks}
-    </div>
+    </React.Fragment>
   );
 }
+
+const StyledJumbotron = styled(Jumbotron)`
+  position:relative;
+
+  :before {
+    bottom: 0;
+    color: var(--success);
+    font-family: FontAwesome;
+    font-size: 900%;
+    /* left: 0; */
+    opacity: 0.2;
+    position: absolute;
+    right: 1.5rem;
+    text-align: center;
+    top: 0;
+    content: "\f135";
+  }
+`;
 
 export default DesktopsPage;

--- a/src/DesktopsPage.js
+++ b/src/DesktopsPage.js
@@ -66,9 +66,6 @@ function DesktopsList({ desktops }) {
         <h1>
           Launch a new desktop session
         </h1>
-        <p>
-          To launch a new desktop session
-        </p>
         <ul>
           <li>Select the desktop session type from the list below.</li>
           <li>Click "Launch".</li>
@@ -91,16 +88,15 @@ const StyledJumbotron = styled(Jumbotron)`
     font-size: 12em;
     opacity: 0.2;
     position: absolute;
-    text-align: center;
 
-    @media (max-width: 1099.98px) {
+    @media (max-width: 1199.98px) {
       top: 50%;
       left: 50%;
       bottom: unset;
       right: unset;
       transform: translate(-50%, -50%);
     }
-    @media (min-width: 1100px) {
+    @media (min-width: 1200px) {
       top: 50%;
       left: unset;
       bottom: unset;

--- a/src/SessionsPage.js
+++ b/src/SessionsPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components'
 import { Link } from "react-router-dom";
 
 import Overlay, { OverlayContainer } from './Overlay';
@@ -88,19 +89,47 @@ function SessionsList({ reload, sessions }) {
       );
     }
   );
+
+  return (
+    <React.Fragment>
+      <IntroCard sessions={sessions} />
+      {decks}
+    </React.Fragment>
+  );
+}
+
+const IntroCard = styled(({ className, sessions }) => {
   const sessionOrSessions = sessions.length === 1 ? 'session' : 'sessions';
 
   return (
-    <div>
-      <p>
+    <div className={`${className} card card-body mb-2`}>
+      <p className="card-text">
         You have {sessions.length} currently running desktop
         {' '}{sessionOrSessions}.  Use the <i>Connect</i> button to establish
         a connection to a desktop session or the <i>Terminate</i> button to
         shutdown a desktop session.
       </p>
-      {decks}
     </div>
   );
-}
+})`
+  :before {
+    color: var(--success);
+    content: "\f108";
+    font-family: FontAwesome;
+    opacity: 0.2;
+    position: absolute;
+    top: 50%;
+    left: 24px;
+    bottom: unset;
+    right: 32px;
+    right: unset;
+    transform: translateY(-50%);
+    font-size: 3em;
+  }
+
+  .card-text {
+    padding-left: 64px;
+  }
+`;
 
 export default SessionsPage;


### PR DESCRIPTION
The desktops page now looks like this

![image](https://user-images.githubusercontent.com/287050/78247798-6b9beb00-74e3-11ea-9b6a-c8da857b00e5.png)

Compare with the picture in #13.  It has more colour and an icon.  Perhaps, more can be done with adding in details of the cluster; but that is what we have for now.

The sessions page is also changed slightly.

![image](https://user-images.githubusercontent.com/287050/78247922-a00fa700-74e3-11ea-98f0-4fedb9d5560f.png)

The introductory text is now in a card and has more colour and an icon.  Again more could be done with adding details of the cluster.

---

We may want to introduce consistency in whether we're using a jumbotron or a card for the page introduction / page header.  At the moment I'm not sure which of those two designs I prefer.  I'll likely come to a conclusion as I see it more in action.